### PR TITLE
Fix cache key when args is an object

### DIFF
--- a/src/GRPCDataSource.ts
+++ b/src/GRPCDataSource.ts
@@ -47,7 +47,7 @@ abstract class GRPCDataSource<TContext = any> extends DataSource {
   getCacheKey(args: any, rpcName: string) {
     return crypto
       .createHash("sha1")
-      .update(JSON.stringify(args + rpcName))
+      .update(JSON.stringify(args) + rpcName)
       .digest("base64");
   }
 }


### PR DESCRIPTION
When args is an object, the query was failing on getCacheKey since it was attempting to add a string (rpcName) to the object (args), this stringifies just the arguments, and then adds the rpcName to it